### PR TITLE
Update README.md

### DIFF
--- a/runtime/objc/README.md
+++ b/runtime/objc/README.md
@@ -18,7 +18,13 @@ Hello.js
 index.js
 ```
 
-### 1. Install Manticore-Native Components
+### 1.1. Setup a private npm registry and publish manticore-native
+
+```
+https://docs.npmjs.com/private-modules/intro
+```
+
+### 1.2. Install Manticore-Native Components
 
 ```
 $ npm init


### PR DESCRIPTION
the package is not published to the public npm registry, so update the readme with a step to setup a private registry before npm install.